### PR TITLE
Removed two django 4.0 and django 4.1 warnings

### DIFF
--- a/daterangefilter/__init__.py
+++ b/daterangefilter/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'daterangefilter.apps.DateRangeFilterAppConfig'

--- a/daterangefilter/apps.py
+++ b/daterangefilter/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DateRangeFilterAppConfig(AppConfig):


### PR DESCRIPTION


```
/home/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'daterangefilter' defines default_app_config = 'daterangefilter.apps.DateRangeFilterAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```

and 

```
/home/lib/python3.8/site-packages/daterangefilter/apps.py:7: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```